### PR TITLE
Add getters for maps; formatting changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 nbproject/
+/bin/

--- a/src/me/weisboys/randomsurvival/BlockDrops.java
+++ b/src/me/weisboys/randomsurvival/BlockDrops.java
@@ -17,48 +17,43 @@ import org.bukkit.inventory.ItemStack;
  * @author weisb
  */
 public class BlockDrops implements Listener {
-    
+
     private Map<Material,Material> dropID = new HashMap<>();
 
     private ToggleCommand tcmd;
-    
+
     public BlockDrops(ToggleCommand tc) {
        tcmd = tc;
     }
-    
-    @EventHandler 
+
+    @EventHandler
     public void breakBlock (BlockBreakEvent blockBreak) {
-        
-        if (tcmd.isEnabled())
-        {
-            if ((blockBreak.getBlock().getState() instanceof Container )){
-                return;
-            }
-            
-            blockBreak.setDropItems(false);
-            Block block = blockBreak.getBlock();
-            Material blockType = block.getType();
 
-            if (!dropID.containsKey(blockType))
-            {
-
-                Random random = ThreadLocalRandom.current();
-                //Maps blockType to a random material
-                dropID.put(blockType, Material.values()[random.nextInt(Material.values().length)]); 
-            }
-
-            Material material = dropID.get(blockType);
-            ItemStack droppedItem = new ItemStack(material);
-            block.getWorld().dropItemNaturally(block.getLocation(), droppedItem);
-        
+        if (!tcmd.isEnabled()) return;
+        if (blockBreak.getBlock().getState() instanceof Container) {
+            return;
         }
-        
-      
-        
+
+        blockBreak.setDropItems(false);
+        Block block = blockBreak.getBlock();
+        Material blockType = block.getType();
+
+        if (!dropID.containsKey(blockType)) {
+            Random random = ThreadLocalRandom.current();
+            //Maps blockType to a random material
+            dropID.put(blockType, Material.values()[random.nextInt(Material.values().length)]);
+        }
+
+        Material material = dropID.get(blockType);
+        ItemStack droppedItem = new ItemStack(material);
+        block.getWorld().dropItemNaturally(block.getLocation(), droppedItem);
     }
-    
+
     public void resetMap() {
         dropID.clear();
     }
-    
+
+    public Map<Material,Material> getDropID() {
+        return dropID;
+    }
 }

--- a/src/me/weisboys/randomsurvival/MobDrops.java
+++ b/src/me/weisboys/randomsurvival/MobDrops.java
@@ -18,43 +18,41 @@ import org.bukkit.inventory.ItemStack;
  */
 
 public class MobDrops implements Listener{
-    
+
      private Map<EntityType,Material> dropID = new HashMap<>();
-    
+
      private ToggleCommand tcmd;
      public MobDrops (ToggleCommand tc) {
          tcmd = tc;
      }
-     
-     
-    @EventHandler 
+
+
+    @EventHandler
     public void mobDrop (EntityDeathEvent e) {
-        
-        if (tcmd.isEnabled()){
-              e.getDrops().clear();
-            EntityType entityType = e.getEntity().getType();
-            
-            if (entityType == EntityType.PLAYER ){
-                return;
-            }
-            
-            if (!dropID.containsKey(entityType))
-                {
-
-                    Random random = ThreadLocalRandom.current();
-                    dropID.put(entityType, Material.values()[random.nextInt(Material.values().length)]); 
-                }
-
-            Material material = dropID.get(entityType);
-            ItemStack droppedItem = new ItemStack(material);
-            e.getDrops().add(droppedItem);
+        if (!tcmd.isEnabled()) {
+            return;
         }
-        
-      
+        EntityType entityType = e.getEntity().getType();
+
+        if (entityType == EntityType.PLAYER) {
+            return;
+        }
+        e.getDrops().clear();
+        if (!dropID.containsKey(entityType)) {
+            Random random = ThreadLocalRandom.current();
+            dropID.put(entityType, Material.values()[random.nextInt(Material.values().length)]);
+        }
+
+        Material material = dropID.get(entityType);
+        ItemStack droppedItem = new ItemStack(material);
+        e.getDrops().add(droppedItem);
     }
-    
+
     public void resetMap() {
         dropID.clear();
     }
-    
+
+    public Map<EntityType,Material> getDropID() {
+        return dropID;
+    }
 }


### PR DESCRIPTION
This PR does two things:
- Adds getters for the entity drop map and block drop map
- Changed formatting around a little, and replaced long if statements with "guard clauses" (`if (!condition) return;`)

The getters for the maps are for certain planned add-ons for this plugin 😉 